### PR TITLE
fix leading zero padding in ECDSA sig conversion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-06-22  Peter van Dijk <peter.van.dijk@powerdns.com>, Kees Monshouwer <mind04@monshouwer.eu>
+
+        * Fix leading zero(s) padding in ECDSA sig conversion
+
 2017-01-06  David Blacka  <davidb@verisign.com>
 
         * Released version 0.13

--- a/src/com/verisignlabs/dnssec/security/SignUtils.java
+++ b/src/com/verisignlabs/dnssec/security/SignUtils.java
@@ -526,6 +526,15 @@ public class SignUtils
     s_src_pos = (byte) (r_src_pos + r_src_len); s_pad = 0;
     len = (byte) (6 + r_src_len + s_src_len);
 
+    // leading zeroes are forbidden
+    if (signature[r_src_pos] == 0) {
+       r_src_pos++; r_src_len--; len--;
+    }
+    if (signature[s_src_pos] == 0) {
+       s_src_pos++; s_src_len--; len--;
+    }
+
+    // except when they are mandatory
     if (signature[r_src_pos] < 0) {
         r_pad = 1; len++;
     }

--- a/src/com/verisignlabs/dnssec/security/SignUtils.java
+++ b/src/com/verisignlabs/dnssec/security/SignUtils.java
@@ -527,18 +527,18 @@ public class SignUtils
     len = (byte) (6 + r_src_len + s_src_len);
 
     // leading zeroes are forbidden
-    if (signature[r_src_pos] == 0) {
-       r_src_pos++; r_src_len--; len--;
+    while (signature[r_src_pos] == 0 && r_src_len > 0) {
+      r_src_pos++; r_src_len--; len--;
     }
-    if (signature[s_src_pos] == 0) {
-       s_src_pos++; s_src_len--; len--;
+    while (signature[s_src_pos] == 0 && s_src_len > 0) {
+      s_src_pos++; s_src_len--; len--;
     }
 
     // except when they are mandatory
-    if (signature[r_src_pos] < 0) {
-        r_pad = 1; len++;
+    if (r_src_len > 0 && signature[r_src_pos] < 0) {
+      r_pad = 1; len++;
     }
-    if (signature[s_src_pos] < 0) {
+    if (s_src_len > 0 && signature[s_src_pos] < 0) {
       s_pad = 1; len++;
     }
     byte[] sig = new byte[len];


### PR DESCRIPTION
'Recently', it appears the ECDSA signature verifier (or some related component) that Java provides has gotten stricter. This patch fixes leading zero padding so it complies fully with the BER/DER spec, thus avoiding spurious validation failures when using a newer Java.

I notice that `convertDSASignature` does basically the same but looks entirely different. I did not check that one for correct behaviour.