### PR TITLE
exit(1) if the zone had errors

### DIFF
--- a/src/com/verisignlabs/dnssec/cl/VerifyZone.java
+++ b/src/com/verisignlabs/dnssec/cl/VerifyZone.java
@@ -147,13 +147,13 @@ public class VerifyZone extends CLBase
     if (errors > 0)
     {
       System.out.println("zone did not verify.");
+      System.exit(1);
     }
     else
     {
       System.out.println("zone verified.");
+      System.exit(0);
     }
-
-    System.exit(0);
   }
 
   public static void main(String[] args)


### PR DESCRIPTION
This makes `jdnssec-verifyzone` vastly more useful in scripts.