### PR TITLE
Set javac options for source and target to JDK7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,9 @@
            classpathref="project.classpath"
            deprecation="true"
            includeantruntime="false"
-           includes="com/verisignlabs/dnssec/" />
+           includes="com/verisignlabs/dnssec/"
+           source="1.7"
+           target="1.7" />
   </target>
 
   <target name="sectools-jar" depends="usage,sectools">


### PR DESCRIPTION
The build script currently doesn't specify `source` and `target` for the `<javac>` task. Therefore, the build result will depend on the current JDK. The last release for example was build using JDK8 and also only works with JDK8.

The source compiles fine with `source` and `target` set to `1.7`. The resulting JAR file will therefore also work on JDK7.

What do you think?