### PR TITLE
fix handling of IOExceptions when reading zone files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,13 @@
+2024-11-02  David Blacka  <david@blacka.com>
+
+        * Handle I/O errors from ZoneUtils.readZoneFile() correctly (issue #19).
+
 2024-04-13  David Blacka  <david@blacka.com>
 
 	* Remove support for ECC_GOST
 	* Create a new DSAlgorithm class, move DS creation into that
 	* Add support for DS algorithms 3 and 4 -- bouncycastle crypto
-	provider used for DS algoirthm 3 (GOST R 34.11-94)
+	provider used for DS algorithm 3 (GOST R 34.11-94)
 	* Moved support for loading the bouncycastle provider to the new
 	DSAlgorithm class
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version=0.20
+version=0.21

--- a/build.xml
+++ b/build.xml
@@ -166,6 +166,10 @@
     </tar>
   </target>
 
+  <target name="onejar"
+          depends="build-onejar">
+  </target>
+
   <target name="dist"
          depends="bin-dist, src-dist, build-onejar, dist-clean">
   </target>

--- a/src/main/java/com/verisignlabs/dnssec/cl/SignKeyset.java
+++ b/src/main/java/com/verisignlabs/dnssec/cl/SignKeyset.java
@@ -240,7 +240,12 @@ public class SignKeyset extends CLBase {
 
   public void execute() throws Exception {
     // Read in the zone
-    List<Record> records = ZoneUtils.readZoneFile(inputfile, null);
+    List<Record> records = null;
+    try {
+      records = ZoneUtils.readZoneFile(inputfile, null);
+    } catch (java.io.IOException e) {
+      fail("Unable to read input file: " + e.getMessage());
+    }
     if (records == null || records.isEmpty()) {
       fail("empty keyset file");
     }

--- a/src/main/java/com/verisignlabs/dnssec/cl/SignRRset.java
+++ b/src/main/java/com/verisignlabs/dnssec/cl/SignRRset.java
@@ -211,7 +211,12 @@ public class SignRRset extends CLBase {
 
   public void execute() throws Exception {
     // Read in the zone
-    List<Record> records = ZoneUtils.readZoneFile(inputfile, null);
+    List<Record> records = null;
+    try {
+      records = ZoneUtils.readZoneFile(inputfile, null);
+    } catch (java.io.IOException e) {
+      fail("Unable to read input file: " + e.getMessage());
+    }
     if (records == null || records.isEmpty()) {
       fail("empty RRset file");
     }

--- a/src/main/java/com/verisignlabs/dnssec/cl/SignZone.java
+++ b/src/main/java/com/verisignlabs/dnssec/cl/SignZone.java
@@ -64,7 +64,7 @@ public class SignZone extends CLBase {
   private boolean fullySignKeyset = false;
   private List<Name> includeNames = null;
   private boolean useNsec3 = false;
-  private byte[] salt = null;
+  private byte[] salt = {};
   private int iterations = 0;
   private int digestId = DNSSEC.Digest.SHA256;
   private long nsec3paramttl = -1;
@@ -161,7 +161,7 @@ public class SignZone extends CLBase {
         start = Instant.now().minusSeconds(3600);
       }
     } catch (java.text.ParseException e) {
-      fail("unable to parse start time specifiction: " + e);
+      fail("unable to parse start time specifiction: " + e.getMessage());
     }
 
     try {
@@ -172,7 +172,7 @@ public class SignZone extends CLBase {
         expire = Utils.convertDuration(start, "+2592000"); // 30 days
       }
     } catch (java.text.ParseException e) {
-      fail("missing zone file and/or key files");
+      fail("unable to parse end time specficiation: " + e.getMessage());
     }
 
     outputfile = cli.getOptionValue('f');

--- a/src/main/java/com/verisignlabs/dnssec/cl/VerifyZone.java
+++ b/src/main/java/com/verisignlabs/dnssec/cl/VerifyZone.java
@@ -100,7 +100,15 @@ public class VerifyZone extends CLBase {
     zoneverifier.getVerifier().setCurrentTime(currentTime);
     zoneverifier.setIgnoreDuplicateRRs(ignoreDups);
 
-    List<Record> records = ZoneUtils.readZoneFile(zonefile, null);
+    List<Record> records = null;
+    try  {  
+      records = ZoneUtils.readZoneFile(zonefile, null);
+    } catch (java.io.IOException e) {
+      fail(e.getMessage());
+    }
+    if (records == null) {
+      fail("Unable to read a zone file");
+    }
 
     log.fine("verifying zone...");
     int errors = zoneverifier.verifyZone(records);

--- a/src/main/java/com/verisignlabs/dnssec/security/ZoneUtils.java
+++ b/src/main/java/com/verisignlabs/dnssec/security/ZoneUtils.java
@@ -58,13 +58,10 @@ public class ZoneUtils {
    */
   public static List<Record> readZoneFile(String zonefile, Name origin) throws IOException {
     ArrayList<Record> records = new ArrayList<>();
-    try (Master m = zonefile.equals("-") ? new Master(System.in) : new Master(zonefile, origin)) {
-      Record r = null;
-      while ((r = m.nextRecord()) != null) {
-        records.add(r);
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
+    Master m = zonefile.equals("-") ? new Master(System.in) : new Master(zonefile, origin);
+    Record r = null;
+    while ((r = m.nextRecord()) != null) {
+      records.add(r);
     }
 
     return records;


### PR DESCRIPTION
Somehow in the big dnsjava 3.x refactoring (I think) we stopped handling I/O errors when reading zone files correctly.  The central method, `ZoneUtils.readZoneFile()` was printing and then swallowing the `FileNotFoundError` (or whatever), when it had already declared that it could throw IOException.

So, just let it throw, and then catch and `fail()` in the various command-line utilities.

This now does this:

```bash
$ java -jar dist/jdnssec-tools-0.21-pre.jar signzone /tmp/foo
SEVERE: zonefile '/tmp/foo' does not exist
$ echo $?
64

$ java -jar dist/jdnssec-tools-0.21-pre.jar verifyzone /tmp/foo
SEVERE: /tmp/foo (No such file or directory)
$ echo $?
64
```